### PR TITLE
Support newer Gradle versions

### DIFF
--- a/src/main/groovy/org/assertj/generator/gradle/AssertJGeneratorGradlePlugin.groovy
+++ b/src/main/groovy/org/assertj/generator/gradle/AssertJGeneratorGradlePlugin.groovy
@@ -58,7 +58,7 @@ class AssertJGeneratorGradlePlugin implements Plugin<Project> {
             add(project.dependencies.create("org.assertj:assertj-assertions-generator:2.0.0"))
         }
 
-        Configuration compileTestConfig = project.configurations.findByName(JavaPlugin.TEST_COMPILE_CONFIGURATION_NAME)
+        Configuration compileTestConfig = project.configurations.findByName(JavaPlugin.TEST_IMPLEMENTATION_CONFIGURATION_NAME)
         if (compileTestConfig) {
             assertJGeneratorConfiguration.extendsFrom(compileTestConfig)
         }

--- a/src/main/groovy/org/assertj/generator/gradle/tasks/AssertJGenerationTask.groovy
+++ b/src/main/groovy/org/assertj/generator/gradle/tasks/AssertJGenerationTask.groovy
@@ -190,7 +190,6 @@ class AssertJGenerationTask extends SourceTask {
         super.getSource()
     }
 
-    @Internal
     private def getClassNames() {
         Map<File, String> fullyQualifiedNames = new HashMap<>(sourceDirectorySet.files.size())
 


### PR DESCRIPTION
As newer versions of Gradle require the use of `testImplementation`,
instead of `testCompile`, and the `@Internal` use on a getter is not
allowed, we should amend our configuration to allow support with newer
versions of Gradle, while retaining previous versions' support, too.

Closes #17.
