### PR TITLE
[Simplify] Remove unused methods, add `ListProperty<>` values for `Te…

### DIFF
--- a/src/main/groovy/org/assertj/generator/gradle/internal/tasks/DefaultAssertJGeneratorSourceSet.groovy
+++ b/src/main/groovy/org/assertj/generator/gradle/internal/tasks/DefaultAssertJGeneratorSourceSet.groovy
@@ -20,10 +20,11 @@ import org.assertj.generator.gradle.tasks.config.EntryPointGeneratorOptions
 import org.assertj.generator.gradle.tasks.config.Templates
 import org.gradle.api.Action
 import org.gradle.api.file.SourceDirectorySet
-import org.gradle.api.internal.file.SourceDirectorySetFactory
-import org.gradle.api.internal.tasks.DefaultSourceSet
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.SourceSet
 import org.gradle.util.ConfigureUtil
+
+import javax.inject.Inject
 
 /**
  * Simple, default implementation of {@link AssertJGeneratorSourceSet}
@@ -38,10 +39,14 @@ class DefaultAssertJGeneratorSourceSet extends DefaultAssertJGeneratorOptions im
 
     private final SourceDirectorySet assertJDirectorySet
 
-    DefaultAssertJGeneratorSourceSet(SourceSet sourceSet, SourceDirectorySetFactory sourceDirectorySetFactory) {
-        super()
+    @Inject
+    DefaultAssertJGeneratorSourceSet(ObjectFactory objectFactory, SourceSet sourceSet) {
+        super(objectFactory)
         this.name = sourceSet.name
-        this.assertJDirectorySet = sourceDirectorySetFactory.create("${((DefaultSourceSet) sourceSet).displayName} AssertJ Sources")
+        this.assertJDirectorySet = objectFactory.sourceDirectorySet(
+                "$sourceSet AssertJ Sources",
+                sourceSet.name,
+        )
 
         // We default to the java directory
         assertJ.setSrcDirs(["src/${this.name}/java"])

--- a/src/main/groovy/org/assertj/generator/gradle/internal/tasks/config/DefaultAssertJGeneratorOptions.groovy
+++ b/src/main/groovy/org/assertj/generator/gradle/internal/tasks/config/DefaultAssertJGeneratorOptions.groovy
@@ -19,9 +19,11 @@ import org.assertj.assertions.generator.AssertionsEntryPointType
 import org.assertj.generator.gradle.tasks.config.AssertJGeneratorOptions
 import org.assertj.generator.gradle.tasks.config.EntryPointGeneratorOptions
 import org.assertj.generator.gradle.tasks.config.Templates
+import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.SourceSet
 import org.gradle.util.ConfigureUtil
 
+import javax.inject.Inject
 import java.nio.file.Path
 import java.nio.file.Paths
 
@@ -39,15 +41,16 @@ class DefaultAssertJGeneratorOptions implements AssertJGeneratorOptions, Seriali
 
     protected String outputDir
 
-    DefaultAssertJGeneratorOptions() {
+    @Inject
+    DefaultAssertJGeneratorOptions(ObjectFactory objects) {
         this.outputDir = "generated-src/${SOURCE_SET_NAME_TAG}-test/java"
 
         skip = true
         hierarchical = null
-        templates = new Templates()
+        templates = objects.newInstance(Templates)
 
         // default entry points
-        this._entryPoints = new EntryPointGeneratorOptions()
+        this._entryPoints = objects.newInstance(EntryPointGeneratorOptions)
         this._entryPoints.only(AssertionsEntryPointType.STANDARD)
     }
 


### PR DESCRIPTION
…mplates`

This is extracted from #31

This removes unused methods that were knock ons from #30. This fixes issues with serialization of the `Templates` value when computing if the tasks should run.

Fixes #15. 