### PR TITLE
[Simplify] Remove auto-application of `java` plugin

### DIFF
--- a/src/test/groovy/org/assertj/generator/gradle/SimpleBuild.groovy
+++ b/src/test/groovy/org/assertj/generator/gradle/SimpleBuild.groovy
@@ -95,20 +95,19 @@ class SimpleBuild {
             """
     }
 
-
     @Test
     void for_single_class() {
-
         buildFile << """
             // Add required plugins and source sets to the sub projects
-            plugins { id "org.assertj.generator" } // Note must use this syntax
+            plugins {
+              id "org.assertj.generator" // Note must use this syntax
+              id "java" 
+            } 
 
             // Override defaults
             sourceSets {
                 main {
-                    assertJ {
-                          
-                    }
+                    assertJ { }
                 }
             }
             
@@ -119,8 +118,6 @@ class SimpleBuild {
                         
             dependencies { 
                 implementation group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
-                
-                implementation group: 'com.google.guava', name: 'guava', version: '28.1-jre'
                 
                 testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.24.2'
                 testImplementation group: 'junit', name: 'junit', version: '4.13.1'

--- a/src/test/groovy/org/assertj/generator/gradle/TestUtils.groovy
+++ b/src/test/groovy/org/assertj/generator/gradle/TestUtils.groovy
@@ -28,7 +28,10 @@ class TestUtils {
     static def buildFile(File file, @Language("Groovy") String content) {
         file << """
             // Add required plugins and source sets to the sub projects
-            plugins { id "org.assertj.generator" } // Note must use this syntax
+            plugins { 
+                id "org.assertj.generator" // Note must use this syntax
+                id "java"
+            } 
             
             ${content}
             


### PR DESCRIPTION
This was objectively wrong and shouldnt have been done. The correct approach is to register this plugin when the `java` plugin is registered.

Extracted from #31