### PR TITLE
[Modernize] Use `*.class` files as sources instead of `*.java`

### DIFF
--- a/src/main/kotlin/org/assertj/generator/gradle/AssertJGeneratorGradlePlugin.kt
+++ b/src/main/kotlin/org/assertj/generator/gradle/AssertJGeneratorGradlePlugin.kt
@@ -67,6 +67,9 @@ open class AssertJGeneratorGradlePlugin @Inject internal constructor(
 
     // Create a new task for the source set
     val generationTask = project.tasks.register<AssertJGenerationTask>(generateTaskName, objects, this)
+    generationTask.configure { task ->
+      task.classDirectories.srcDir(this.java.classesDirectory)
+    }
 
     javaPlugin.sourceSets.named("test").configure { sourceSet ->
       sourceSet.java.srcDir(generationTask.flatMap { it.outputDir })

--- a/src/main/kotlin/org/assertj/generator/gradle/internal/tasks/AssertionsGeneratorReport.kt
+++ b/src/main/kotlin/org/assertj/generator/gradle/internal/tasks/AssertionsGeneratorReport.kt
@@ -33,8 +33,8 @@ internal class AssertionsGeneratorReport(
   private val inputClassesNotFound = TreeSet<String>()
   private val userTemplates = mutableListOf<String>()
 
-  fun addGeneratedAssertionFiles(vararg generatedCustomAssertionFiles: File) {
-    generatedCustomAssertionFileNames += generatedCustomAssertionFiles.map { it.canonicalPath }
+  fun addGeneratedAssertionFiles(vararg files: File) {
+    generatedCustomAssertionFileNames += files.map { it.canonicalPath }
   }
 
   fun getReportContent(): String = buildString {

--- a/src/main/kotlin/org/assertj/generator/gradle/tasks/AssertJGenerationTask.kt
+++ b/src/main/kotlin/org/assertj/generator/gradle/tasks/AssertJGenerationTask.kt
@@ -252,12 +252,10 @@ private fun getFullyQualifiedClassForFile(srcDirs: List<Path>, path: Path): Stri
   // Ignore package-info.java, it's not supposed to be included.
   if (path.fileName == PACKAGE_INFO_PATH) return null
   val className = path.nameWithoutExtension
-  if ('$' in className) return null
 
   val srcDir = srcDirs.single { path.startsWith(it) }
-  val relativePath = path.relativeTo(srcDir).parent
+  val relativePath = path.relativeTo(srcDir).parent.toString()
+    .replace(File.separatorChar, '.')
 
   return "$relativePath.$className"
-    .replace(File.separatorChar, '.')
-    .replace('$', '.')
 }

--- a/src/main/kotlin/org/assertj/generator/gradle/tasks/config/AssertJGeneratorExtension.kt
+++ b/src/main/kotlin/org/assertj/generator/gradle/tasks/config/AssertJGeneratorExtension.kt
@@ -16,6 +16,7 @@ import org.assertj.assertions.generator.AssertionsEntryPointType
 import org.gradle.api.Action
 import org.gradle.api.Project
 import org.gradle.api.file.DirectoryProperty
+import org.gradle.api.file.SourceDirectorySet
 import org.gradle.api.model.ObjectFactory
 import org.gradle.api.tasks.SourceSet
 import org.gradle.kotlin.dsl.newInstance
@@ -30,6 +31,9 @@ open class AssertJGeneratorExtension @Inject internal constructor(
   project: Project,
   sourceSet: SourceSet
 ) {
+  val classDirectories: SourceDirectorySet =
+    objects.sourceDirectorySet("assertJClasses", "Classes to generate AssertJ assertions from")
+
   /**
    * Generate generating Soft Assertions entry point class.
    * @return templates value, never {@code null}

--- a/src/test/groovy/org/assertj/generator/gradle/IncrementalBuild.groovy
+++ b/src/test/groovy/org/assertj/generator/gradle/IncrementalBuild.groovy
@@ -161,9 +161,9 @@ class IncrementalBuild {
         assertFiles()
     }
 
-    private def assertFiles(String sourceSet = "main") {
+    private def assertFiles() {
         final Path generatedPackagePath = testProjectDir.root.toPath()
-                .resolve("build/generated-src/${sourceSet}-test/java")
+                .resolve("build/generated-src/main-test/java")
                 .resolve(packagePath)
 
         List<Path> files = ["H1", "H2"].collect {

--- a/src/test/groovy/org/assertj/generator/gradle/SimpleBuild.groovy
+++ b/src/test/groovy/org/assertj/generator/gradle/SimpleBuild.groovy
@@ -15,7 +15,6 @@ package org.assertj.generator.gradle
 import org.gradle.testkit.runner.GradleRunner
 import org.gradle.testkit.runner.TaskOutcome
 import org.junit.Before
-import org.junit.Ignore
 import org.junit.Rule
 import org.junit.Test
 import org.junit.rules.TemporaryFolder
@@ -70,6 +69,20 @@ class SimpleBuild {
             }
             """.stripIndent()
 
+        File nestedWorldJava = srcPackagePath.resolve('OtherNestedWorld.java').toFile()
+
+        nestedWorldJava << """
+            package org.example;
+            
+            public final class OtherNestedWorld {
+                public boolean isBrainy = false;
+                
+                static class Nested {
+                  public boolean isSomethingElse = false;
+                }
+            }
+            """.stripIndent()
+
         File testDir = testProjectDir.newFolder('src', 'test', 'java')
 
         testDir.toPath().resolve(packagePath).toFile().mkdirs()
@@ -81,7 +94,7 @@ class SimpleBuild {
             package org.example;
             
             import org.junit.Test;
-            import static org.example.HelloWorldAssert.assertThat;
+            import static org.example.Assertions.assertThat;
             
             public final class HelloWorldTest {
                 
@@ -90,6 +103,12 @@ class SimpleBuild {
                     HelloWorld hw = new HelloWorld();
                     assertThat(hw).hasFoo(-1)
                                   .doesNotHaveSomeBrains();
+                }
+                
+                @Test
+                public void checkClassWithNested() {
+                    OtherNestedWorld ow = new OtherNestedWorld();
+                    assertThat(ow).isNotBrainy();
                 }
             }
             """
@@ -133,18 +152,15 @@ class SimpleBuild {
 
         assert result.task(':generateAssertJ').outcome == TaskOutcome.SUCCESS
         assert result.task(':test').outcome == TaskOutcome.SUCCESS
-
     }
 
     @Test
-    @Ignore("Test fails due to groovy incompatibility")
     void exclude_class() {
-
         TestUtils.buildFile(buildFile, """
             sourceSets {
                 main {
                     assertJ {
-                        source.exclude '**/org/example/OtherWorld*'
+                        classDirectories.exclude '**/org/example/OtherWorld*'
                     }
                 }
             }
@@ -159,7 +175,10 @@ class SimpleBuild {
 
         assert result.task(':generateAssertJ').outcome == TaskOutcome.SUCCESS
         assert result.task(':compileTestJava').outcome == TaskOutcome.SUCCESS
+
+        def packagePath = testProjectDir.root.toPath()
+                .resolve("build/generated-src/main-test/java")
+                .resolve("org/example")
+        assert !packagePath.toFile().listFiles().find { it.name == "OtherWorldAssert.java" }
     }
-
-
 }

--- a/src/test/groovy/org/assertj/generator/gradle/SimpleBuild.groovy
+++ b/src/test/groovy/org/assertj/generator/gradle/SimpleBuild.groovy
@@ -77,7 +77,7 @@ class SimpleBuild {
             public final class OtherNestedWorld {
                 public boolean isBrainy = false;
                 
-                static class Nested {
+                public static class Nested {
                   public boolean isSomethingElse = false;
                 }
             }
@@ -109,6 +109,12 @@ class SimpleBuild {
                 public void checkClassWithNested() {
                     OtherNestedWorld ow = new OtherNestedWorld();
                     assertThat(ow).isNotBrainy();
+                }
+                
+                @Test
+                public void checkNestedClass() {
+                    OtherNestedWorld.Nested n = new OtherNestedWorld.Nested();
+                    assertThat(n).isNotSomethingElse();
                 }
             }
             """


### PR DESCRIPTION
This is a smaller change that has a few big benefits:

1. Removes all deprecation warnings :tada:
2. Inputs are now correctly handled, if there is any change in classes we will always regenerate everything -- previously it would only regenerate changed files which is misleading due to the reflected data potentially being incorrect
3. Excluding files via `sourceSet.exclude` works again -- restoring the ignored test 
    - part of a fix for #16
5. This enables us to add support for other JVM languages: Groovy, Kotlin, etc. 🚀 

Closes #5 
Closes #17