### PR TITLE
[Filtering] Add support for filtering classe like Maven plugin

### DIFF
--- a/src/main/kotlin/org/assertj/generator/gradle/tasks/config/AssertJGeneratorExtension.kt
+++ b/src/main/kotlin/org/assertj/generator/gradle/tasks/config/AssertJGeneratorExtension.kt
@@ -13,6 +13,7 @@
 package org.assertj.generator.gradle.tasks.config
 
 import org.assertj.assertions.generator.AssertionsEntryPointType
+import org.assertj.generator.gradle.tasks.config.patterns.JavaClassPatternFilterable
 import org.assertj.generator.gradle.tasks.config.patterns.JavaPackageNamePatternFilterable
 import org.gradle.api.Action
 import org.gradle.api.Project
@@ -34,6 +35,12 @@ open class AssertJGeneratorExtension @Inject internal constructor(
 ) {
   val classDirectories: SourceDirectorySet =
     objects.sourceDirectorySet("assertJClasses", "Classes to generate AssertJ assertions from")
+
+  val classes: JavaClassPatternFilterable = objects.newInstance()
+
+  fun classes(action: Action<in JavaClassPatternFilterable>): AssertJGeneratorExtension = apply {
+    action.execute(classes)
+  }
 
   val packages: JavaPackageNamePatternFilterable = objects.newInstance()
 

--- a/src/main/kotlin/org/assertj/generator/gradle/tasks/config/patterns/JavaClassPatternFilterable.kt
+++ b/src/main/kotlin/org/assertj/generator/gradle/tasks/config/patterns/JavaClassPatternFilterable.kt
@@ -1,0 +1,59 @@
+/*
+ * Copyright 2023. assertj-generator-gradle-plugin contributors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except in compliance with
+ * the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License is distributed on
+ * an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License for the
+ * specific language governing permissions and limitations under the License.
+ */
+package org.assertj.generator.gradle.tasks.config.patterns
+
+import com.google.common.reflect.TypeToken
+import org.assertj.generator.gradle.tasks.config.patterns.JavaNamePatternCompiler.compilePattern
+import java.io.IOException
+import java.io.ObjectInputStream
+import java.io.ObjectOutputStream
+import java.io.Serializable
+
+/**
+ * Implements a similar construction to [org.gradle.api.tasks.util.PatternFilterable] that will match
+ * [TypeToken] instances.
+ */
+open class JavaClassPatternFilterable internal constructor() :
+  JavaIdentifierNamePatternFilterableBase<TypeToken<*>, JavaClassPatternFilterable>(), Serializable {
+
+  override fun compilePatterns(patterns: Iterable<String>): Sequence<PatternPredicate<TypeToken<*>>> {
+    return patterns.asSequence().map { TypeNamePredicate.compile(it) }
+  }
+
+  @Throws(IOException::class)
+  protected fun writeObject(o: ObjectOutputStream) {
+    super.writeObjectImpl(o)
+  }
+
+  @Throws(IOException::class, ClassNotFoundException::class)
+  protected fun readObject(i: ObjectInputStream) {
+    super.readObjectImpl(i)
+  }
+
+  internal data class TypeNamePredicate(
+    override val pattern: String,
+    private val namePattern: Regex,
+  ) : PatternPredicate<TypeToken<*>> {
+    override fun test(t: TypeToken<*>): Boolean {
+      return namePattern.matches(t.type.typeName)
+    }
+
+    companion object {
+      fun compile(pattern: String): TypeNamePredicate = TypeNamePredicate(pattern, compilePattern(pattern))
+    }
+  }
+
+  companion object {
+    private const val serialVersionUID = 9418631994L
+  }
+}

--- a/src/test/groovy/org/assertj/generator/gradle/parameter/ClassesFilter.groovy
+++ b/src/test/groovy/org/assertj/generator/gradle/parameter/ClassesFilter.groovy
@@ -27,9 +27,9 @@ import java.util.function.Supplier
 import static org.assertj.core.api.Assertions.assertThat
 
 /**
- * Checks that we can include/exclude classes via the `packages` filter.
+ * Checks that we can include/exclude classes via the `classes` filter.
  */
-class PackageFilter {
+class ClassesFilter {
 
     @Rule
     public final TemporaryFolder testProjectDir = new TemporaryFolder()
@@ -103,15 +103,15 @@ class PackageFilter {
     }
 
     @Test
-    void include_package_simple() {
+    void include_class_simple() {
         buildFile {
             """
             assertJ {
                 entryPoints {
                     classPackage = "org.example"
                 }
-                packages {
-                    include "org.example.hello"
+                classes {
+                    include "org.example.hello.HelloWorld"
                 }
             }
             """.stripIndent()
@@ -127,15 +127,15 @@ class PackageFilter {
     }
 
     @Test
-    void include_package_pattern() {
+    void include_class_pattern() {
         buildFile {
             """
             assertJ {
                 entryPoints {
                     classPackage = "org.example"
                 }
-                packages {
-                    include "org.example.he*"
+                classes {
+                    include "org.example.hello.Hello*"
                 }
             }
             """.stripIndent()
@@ -151,15 +151,15 @@ class PackageFilter {
     }
 
     @Test
-    void include_package_that_does_not_exist_and_valid() {
+    void include_class_that_does_not_exist_and_valid() {
         buildFile {
             """
             assertJ {
                 entryPoints {
                     classPackage = "org.example"
                 }
-                packages {
-                    include "org.example.he*", "org.example.does_not_exist"
+                classes {
+                    include "org.example.hello.*", "org.example.does_not_exist"
                 }
             }
             """.stripIndent()
@@ -175,14 +175,14 @@ class PackageFilter {
     }
 
     @Test
-    void include_package_double_wildcard() {
+    void include_class_double_wildcard() {
         buildFile {
             """
             assertJ {
                 entryPoints {
                     classPackage = "org.example"
                 }
-                packages {
+                classes {
                     include "org.example.hello**"
                 }
             }
@@ -199,15 +199,15 @@ class PackageFilter {
     }
 
     @Test
-    void exclude_package_simple() {
+    void exclude_class_simple() {
         buildFile {
             """
             assertJ {
                 entryPoints {
                     classPackage = "org.example"
                 }
-                packages {
-                    exclude "org.example.other"
+                classes {
+                    exclude "org.example.other.OtherWorld"
                 }
             }
             """.stripIndent()
@@ -223,15 +223,15 @@ class PackageFilter {
     }
 
     @Test
-    void exclude_package_pattern() {
+    void exclude_class_pattern() {
         buildFile {
             """
             assertJ {
                 entryPoints {
                     classPackage = "org.example"
                 }
-                packages {
-                    exclude "org.example.ot*"
+                classes {
+                    exclude "org.example.other.*"
                 }
             }
             """.stripIndent()
@@ -246,34 +246,16 @@ class PackageFilter {
         assertThat(generatedBasePackagePath.resolve("hello/sub")).exists()
     }
 
-    private File setupTestHelloAndSub() {
-        testFile {
-            """
-            @Test
-            public void checkHello() {
-                HelloWorld hw = new HelloWorld();
-                assertThat(hw).doesNotHaveSomeBrains();
-            }
-            
-            @Test
-            public void checkOther() {
-                SubHelloWorld shw = new SubHelloWorld();
-                assertThat(shw).hasFoo(-1);
-            }
-            """.stripIndent()
-        }
-    }
-
     @Test
-    void exclude_package_that_does_not_exist_and_valid() {
+    void exclude_class_that_does_not_exist_and_valid() {
         buildFile {
             """
             assertJ {
                 entryPoints {
                     classPackage = "org.example"
                 }
-                packages {
-                    exclude "org.example.ot*", "org.example.does_not_exist"
+                classes {
+                    exclude "org.example.other.*", "org.example.does_not_exist"
                 }
             }
             """.stripIndent()
@@ -303,14 +285,14 @@ class PackageFilter {
     }
 
     @Test
-    void exclude_package_double_wildcard() {
+    void exclude_class_double_wildcard() {
         buildFile {
             """
             assertJ {
                 entryPoints {
                     classPackage = "org.example"
                 }
-                packages {
+                classes {
                     exclude "org.example.**"
                 }
             }
@@ -341,16 +323,16 @@ class PackageFilter {
     }
 
     @Test
-    void include_double_wildcard_but_exclude_specific_package() {
+    void include_double_wildcard_but_exclude_specific_class() {
         buildFile {
             """
             assertJ {
                 entryPoints {
                     classPackage = "org.example"
                 }
-                packages {
+                classes {
                     include "org.example.hello**"
-                    exclude "org.example.hello.sub"
+                    exclude "org.example.hello.sub.*"
                 }
             }
             """.stripIndent()
@@ -433,5 +415,23 @@ class PackageFilter {
                 ${testContent.get()}
             }
             """.stripIndent()
+    }
+
+    private File setupTestHelloAndSub() {
+        testFile {
+            """
+            @Test
+            public void checkHello() {
+                HelloWorld hw = new HelloWorld();
+                assertThat(hw).doesNotHaveSomeBrains();
+            }
+            
+            @Test
+            public void checkOther() {
+                SubHelloWorld shw = new SubHelloWorld();
+                assertThat(shw).hasFoo(-1);
+            }
+            """.stripIndent()
+        }
     }
 }


### PR DESCRIPTION
This adds package filters similar to how the Maven plugin filters in its `<classes>` block. This supports ant-like patterns similar to how patterns filter.

Follows #53 which added similar support for `packages` filtering

Closes #16.