### PR TITLE
[dependabot] Enable auto-merge for patch updates

### DIFF
--- a/.github/workflows/dependabot-auto-merge-patch.yml
+++ b/.github/workflows/dependabot-auto-merge-patch.yml
@@ -1,0 +1,25 @@
+name: Dependabot auto-merge
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  dependabot:
+    runs-on: ubuntu-latest
+    if: ${{ github.actor == 'dependabot[bot]' }}
+    steps:
+      - name: Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v1
+        with:
+          github-token: "${{secrets.GITHUB_TOKEN}}" 
+
+      - name: Enable auto-merge for minor patch bumps
+        if: ${{ steps.metadata.outputs.update-type == 'version-update:semver-patch' }}
+        run: |
+          gh pr merge --auto --merge "$PR_URL" 
+        env:
+          PR_URL: ${{github.event.pull_request.html_url}}
+          GITHUB_TOKEN: ${{secrets.GITHUB_TOKEN}}


### PR DESCRIPTION
This adds auto-merge support for patch updates. This avoids some needless reviews.