### PR TITLE
[Tests] Port tests to use `gradle-plugin-better-testing-junit5` for f…

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
 
     strategy:
       matrix:
-        gradle-version: [ '7.5.1', '7.6.2', '8.0.1', '8.2.1' ]
+        gradle-version: [ '7.6.2', '8.0.1', '8.2.1' ]
 
     steps:
       - uses: actions/setup-java@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,15 @@
 name: Build and test
 on: [ push, pull_request ]
+
 jobs:
-  JVM-Run-Gradle-Check:
+  ci:
     runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
+
+    strategy:
+      matrix:
+        gradle-version: [ '7.5.1', '7.6.2', '8.0.1', '8.2.1' ]
+
     steps:
       - uses: actions/setup-java@v3
         with:
@@ -12,8 +19,8 @@ jobs:
       - uses: actions/checkout@v3
 
       - uses: gradle/gradle-build-action@v2
-
-      - name: Execute Gradle build
-        run: ./gradlew check --continue
+        with:
+          gradle-version: ${{ matrix.gradle-version }}
+          arguments: check --continue
 
 #    TODO Add publish on tag support

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -70,13 +70,8 @@ dependencies {
   implementation(gradleKotlinDsl())
   implementation("com.google.guava:guava:32.1.2-jre")
 
-  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0")
-  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin-api:1.9.0")
-  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin-api:1.9.0") {
-    capabilities {
-      requireCapability("org.jetbrains.kotlin:kotlin-gradle-plugin-api-gradle76")
-    }
-  }
+  val kotlinVersion = "1.6.21"
+  implementation("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
 
   testCompileOnly("org.jetbrains:annotations:24.0.1")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,7 +74,7 @@ dependencies {
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin-api:1.9.0")
   implementation("org.jetbrains.kotlin:kotlin-gradle-plugin-api:1.9.0") {
     capabilities {
-     requireCapability("org.jetbrains.kotlin:kotlin-gradle-plugin-api-gradle76")
+      requireCapability("org.jetbrains.kotlin:kotlin-gradle-plugin-api-gradle76")
     }
   }
 
@@ -82,8 +82,19 @@ dependencies {
 
   testImplementation(localGroovy())
   testImplementation(gradleTestKit())
-  testImplementation("junit:junit:4.13.2")
+
+  val junitVersion = "5.10.0"
   testImplementation("org.assertj:assertj-core:3.24.2")
+  testImplementation("org.junit.jupiter:junit-jupiter-api:$junitVersion")
+  testImplementation("net.navatwo:gradle-plugin-better-testing-junit5:0.0.0")
+
+  testRuntimeOnly("org.junit.jupiter:junit-jupiter-engine:$junitVersion")
+}
+
+tasks.test {
+  useJUnitPlatform()
+
+  jvmArgs("-Djunit.jupiter.extensions.autodetection.enabled=true")
 }
 
 tasks.check {

--- a/src/test/kotlin/org/assertj/generator/gradle/IncrementalBuild.kt
+++ b/src/test/kotlin/org/assertj/generator/gradle/IncrementalBuild.kt
@@ -12,16 +12,11 @@
  */
 package org.assertj.generator.gradle
 
+import net.navatwo.gradle.testkit.junit5.GradleProject
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.generator.gradle.TestUtils.writeDefaultBuildFile
 import org.gradle.testkit.runner.GradleRunner
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.TemporaryFolder
+import org.junit.jupiter.api.Test
 import java.io.File
-import java.nio.file.Path
-import java.nio.file.Paths
 import java.util.function.Consumer
 
 /**
@@ -33,128 +28,64 @@ internal class IncrementalBuild {
   // * Entry point files
   // * File deletion
 
-  @get:Rule
-  val testProjectDir: TemporaryFolder = TemporaryFolder()
-
-  private lateinit var srcPackagePath: Path
-  private lateinit var packagePath: Path
-  private lateinit var h1Java: File
-  private lateinit var h2Java: File
-
-  @Before
-  fun setup() {
-    testProjectDir.newFile("build.gradle").writeDefaultBuildFile()
-
-    val srcDir = testProjectDir.newFolder("src", "main", "java")
-
-    packagePath = Paths.get("org/example/")
-
-    srcPackagePath = srcDir.toPath().resolve(this.packagePath)
-    this.srcPackagePath.toFile().mkdirs()
-    h1Java = this.srcPackagePath.resolve("H1.java").toFile()
-
-    this.h1Java.writeJava(
-      """
-      package org.example;
-      
-      public final class H1 {
-          public boolean isBrainy = false;
-      }
-      """
-    )
-
-    h2Java = this.srcPackagePath.resolve("H2.java").toFile()
-
-    this.h2Java.writeJava(
-      """
-      package org.example;
-      
-      public final class H2 {
-          public boolean isBrainy = false;
-      }
-      """
-    )
-
-    val testDir = testProjectDir.newFolder("src", "test", "java")
-
-    testDir.toPath().resolve(this.packagePath).toFile().mkdirs()
-    val testPackagePath = testDir.toPath().resolve(this.packagePath)
-    testPackagePath.toFile().mkdirs()
-    val helloWorldTestJava = testPackagePath.resolve("H1Test.java").toFile()
-
-    helloWorldTestJava.writeJava(
-      """
-      package org.example;
-      
-      import org.junit.Test;
-      import static org.example.H1Assert.assertThat;
-      
-      public final class H1Test {
-          @Test
-          public void check() {
-              H1 hw = new H1();
-              assertThat(hw).isNotBrainy();
-          }
-      }
-      """
-    )
-  }
+  private val packagePath: File
+    get() = File("org/example")
+  private val File.h1Java: File
+    get() = resolve("src/main/java/org/example/H1.java")
 
   @Test
-  fun `incremental build does not rebuild everything`() {
-    val runner = GradleRunner.create()
-      .withProjectDir(testProjectDir.root)
-      .withDebug(true)
-      .withPluginClasspath()
-      .withArguments("-i", "-s", "build")
+  @GradleProject("incremental-build")
+  fun `incremental build does not rebuild everything`(
+    @GradleProject.Root root: File,
+    @GradleProject.Runner runner: GradleRunner,
+  ) {
+    val buildRunner = runner.withArguments("-i", "-s", "build")
 
-    val firstBuild = runner.build()
+    val firstBuild = buildRunner.build()
 
     assertThat(firstBuild.task(":generateAssertJ")).isSuccessful()
     assertThat(firstBuild.task(":test")).isSuccessful()
 
-    assertFiles()
+    root.assertFiles()
 
-    val secondBuild = runner.build()
+    val secondBuild = buildRunner.build()
     assertThat(secondBuild.task(":generateAssertJ")).isUpToDate()
     assertThat(secondBuild.task(":test")).isUpToDate()
 
-    assertFiles()
+    root.assertFiles()
   }
 
   @Test
-  fun `incremental build rebuild changed single file contents`() {
-    val runner = GradleRunner.create()
-      .withProjectDir(testProjectDir.root)
-      .withDebug(true)
-      .withPluginClasspath()
-      .withArguments("-i", "-s", "build")
+  @GradleProject("incremental-build")
+  fun `incremental build rebuild changed single file contents`(
+    @GradleProject.Root root: File,
+    @GradleProject.Runner runner: GradleRunner,
+  ) {
+    val buildRunner = runner.withArguments("-i", "-s", "build")
 
-    val firstBuild = runner.build()
+    val firstBuild = buildRunner.build()
 
     assertThat(firstBuild.task(":generateAssertJ")).isSuccessful()
     assertThat(firstBuild.task(":test")).isSuccessful()
 
     // get files
-    assertFiles()
+    root.assertFiles()
 
     // modify the contents of H1 that doesn't change the compiled `.class`
-    h1Java.appendText("\n// some changed data")
+    root.h1Java.appendText("\n// some changed data")
 
-    val secondBuild = runner.build()
+    val secondBuild = buildRunner.build()
     // Make sure it did run
     assertThat(secondBuild.task(":generateAssertJ")).isUpToDate()
 
     // However, since we didn't actually change anything, there's nothing to test, thus UP_TO_DATE
     assertThat(secondBuild.task(":test")).isUpToDate()
 
-    assertFiles()
+    root.assertFiles()
   }
 
-  private fun assertFiles() {
-    val generatedPackagePath = testProjectDir.root.toPath()
-      .resolve("build/generated-src/main-test/java")
-      .resolve(packagePath)
+  private fun File.assertFiles() {
+    val generatedPackagePath = resolve("build/generated-src/main-test/java").resolve(packagePath)
 
     val files = listOf("H1", "H2").map {
       generatedPackagePath.resolve("${it}Assert.java")

--- a/src/test/kotlin/org/assertj/generator/gradle/SkipPackageInfo.kt
+++ b/src/test/kotlin/org/assertj/generator/gradle/SkipPackageInfo.kt
@@ -12,126 +12,38 @@
  */
 package org.assertj.generator.gradle
 
+import net.navatwo.gradle.testkit.junit5.GradleProject
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.generator.gradle.TestUtils.writeDefaultBuildFile
 import org.gradle.testkit.runner.GradleRunner
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.TemporaryFolder
-import java.nio.file.Path
-import java.nio.file.Paths
+import org.junit.jupiter.api.Test
+import java.io.File
 
 /**
  * Checks the behaviour of overriding globals in a project
  */
 internal class SkipPackageInfo {
 
-  @get:Rule
-  val testProjectDir: TemporaryFolder = TemporaryFolder()
-
-  private lateinit var generatedPackagePath: Path
-
-  @Before
-  fun setup() {
-    testProjectDir.newFile("build.gradle").writeDefaultBuildFile()
-
-    val srcDir = testProjectDir.newFolder("src", "main", "java")
-
-    val packagePath = Paths.get("org/example/")
-
-    val srcPackagePath = srcDir.toPath().resolve(packagePath)
-    srcPackagePath.toFile().mkdirs()
-    val helloWorldJava = srcPackagePath.resolve("HelloWorld.java").toFile()
-
-    helloWorldJava.writeJava(
-      """
-      package org.example;
-      
-      public final class HelloWorld {
-          
-          // Field
-          public boolean hasSomeBrains = false;
-          
-          // Getter
-          public int getFoo() {
-              return -1;
-          }
-      }
-      """
-    )
-
-    val otherWorldJava = srcPackagePath.resolve("OtherWorld.java").toFile()
-
-    otherWorldJava.writeJava(
-      """
-      package org.example;
-      
-      public final class OtherWorld {
-          public boolean isBrainy = false;
-      }
-      """
-    )
-
-    val pkgInfo = srcPackagePath.resolve("package-info.java").toFile()
-
-    pkgInfo.writeJava(
-      """
-      /** 
-       * Some javadoc comments about the package.
-       */
-      package org.example;
-      """
-    )
-
-    val testDir = testProjectDir.newFolder("src", "test", "java")
-
-    testDir.toPath().resolve(packagePath).toFile().mkdirs()
-    val testPackagePath = testDir.toPath().resolve(packagePath)
-    testPackagePath.toFile().mkdirs()
-    val helloWorldTestJava = testPackagePath.resolve("HelloWorldTest.java").toFile()
-
-    helloWorldTestJava.writeJava(
-      """
-      package org.example;
-      
-      import org.junit.Test;
-      import static org.example.HelloWorldAssert.assertThat;
-      
-      public final class HelloWorldTest {
-          
-          @Test
-          public void check() {
-              HelloWorld hw = new HelloWorld();
-              assertThat(hw).hasFoo(-1)
-                            .doesNotHaveSomeBrains();
-          }
-      }
-      """
-    )
-
-    generatedPackagePath = testProjectDir.newFolder("build", "generated-src", "main-test", "java").toPath()
-      .resolve(packagePath)
-  }
+  private val File.generatedPackagePath: File
+    get() = resolve("build/generated-src/main-test/java")
+      .resolve("org/example")
 
   @Test
-  fun `does not include package info file`() {
-    val result = GradleRunner.create()
-      .withProjectDir(testProjectDir.root)
-      .withDebug(true)
-      .withPluginClasspath()
-      .withArguments("-i", "-s", "check")
-      .build()
+  @GradleProject("simple-build")
+  fun `does not include package info file`(
+    @GradleProject.Root root: File,
+    @GradleProject.Runner runner: GradleRunner,
+  ) {
+    val result = runner.withArguments("-i", "-s", "check").build()
 
     assertThat(result.task(":generateAssertJ")).isSuccessful()
     assertThat(result.task(":test")).isSuccessful()
 
-    assertThat(generatedPackagePath.resolve("Package-InfoAssertions.java"))
-      .`as` { "$generatedPackagePath/Package-InfoAssertions does not exist" }
+    assertThat(root.generatedPackagePath.resolve("Package-InfoAssertions.java"))
+      .`as` { "${root.generatedPackagePath}/Package-InfoAssertions does not exist" }
       .doesNotExist()
-    assertThat(generatedPackagePath.resolve("Assertions.java"))
+    assertThat(root.generatedPackagePath.resolve("Assertions.java"))
       .content()
-      .`as` { "$generatedPackagePath/Assertions does not have \"package-info\" in it" }
+      .`as` { "${root.generatedPackagePath}/Assertions does not have \"package-info\" in it" }
       .doesNotContain("package-info")
   }
 }

--- a/src/test/kotlin/org/assertj/generator/gradle/parameter/PackageFilter.kt
+++ b/src/test/kotlin/org/assertj/generator/gradle/parameter/PackageFilter.kt
@@ -12,105 +12,37 @@
  */
 package org.assertj.generator.gradle.parameter
 
+import net.navatwo.gradle.testkit.junit5.GradleProject
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.generator.gradle.isSuccessful
 import org.assertj.generator.gradle.writeGroovy
 import org.assertj.generator.gradle.writeJava
 import org.gradle.testkit.runner.GradleRunner
 import org.intellij.lang.annotations.Language
-import org.junit.Before
-import org.junit.Rule
-import org.junit.Test
-import org.junit.rules.TemporaryFolder
+import org.junit.jupiter.api.Test
 import java.io.File
-import java.nio.file.Path
-import java.nio.file.Paths
 
 /**
  * Checks that we can include/exclude classes via the `packages` filter.
  */
 internal class PackageFilter {
 
-  @get:Rule
-  val testProjectDir = TemporaryFolder()
+  private val File.helloWorldTestJava: File
+    get() = resolve("src/test/java/org/example/HelloWorldTest.java")
 
-  private lateinit var buildFile: File
-  private lateinit var helloWorldTestJava: File
-  private lateinit var generatedBasePackagePath: Path
+  private val File.generatedBasePackagePath: File
+    get() = resolve("build/generated-src/main-test/java/org/example")
 
-  @Before
-  fun setup() {
-    buildFile = testProjectDir.newFile("build.gradle")
-
-    val srcDir = testProjectDir.newFolder("src", "main", "java")
-
-    val packagePath = Paths.get("org/example/")
-
-    val srcPackagePath = srcDir.toPath().resolve(packagePath)
-    srcPackagePath.toFile().mkdirs()
-    val helloWorldJava = srcPackagePath.resolve("HelloWorld.java").toFile()
-
-    helloWorldJava.writeJava(
-      """
-        package org.example.hello;
-        
-        public final class HelloWorld {
-            
-            // Field
-            public boolean hasSomeBrains = false;
-            
-            // Getter
-            public int getFoo() {
-                return -1;
-            }
-        }
-        """
-    )
-
-    val subHelloWorldJava = srcPackagePath.resolve("sub/SubHelloWorld.java").toFile()
-    subHelloWorldJava.parentFile.mkdirs()
-
-    subHelloWorldJava.writeJava(
-      """
-        package org.example.hello.sub;
-        
-        public final class SubHelloWorld {
-            // Getter
-            public int getFoo() {
-                return -1;
-            }
-        }
-        """
-    )
-
-    val otherWorldJava = srcPackagePath.resolve("OtherWorld.java").toFile()
-
-    otherWorldJava.writeJava(
-      """
-        package org.example.other;
-        
-        public final class OtherWorld {
-            public boolean isBrainy = false;
-        }
-        """
-    )
-
-    val testDir = testProjectDir.newFolder("src", "test", "java")
-
-    testDir.toPath().resolve(packagePath).toFile().mkdirs()
-    val testPackagePath = testDir.toPath().resolve(packagePath)
-    testPackagePath.toFile().mkdirs()
-
-    helloWorldTestJava = testPackagePath.resolve("HelloWorldTest.java").toFile()
-
-    generatedBasePackagePath = testProjectDir.root.toPath()
-      .resolve("build/generated-src/main-test/java")
-      .resolve(packagePath)
-  }
+  private val File.buildFile: File
+    get() = resolve("build.gradle")
 
   @Test
-  fun `include package simple`() {
-    buildFile(
+  @GradleProject("package-filter")
+  fun `include package simple`(
+    @GradleProject.Root root: File,
+    @GradleProject.Runner runner: GradleRunner,
+  ) {
+    root.buildFile(
       """
         assertJ {
             entryPoints {
@@ -123,18 +55,22 @@ internal class PackageFilter {
         """
     )
 
-    setupTestHelloWorld()
+    root.setupTestHelloWorld()
 
-    runAndAssertBuild()
+    runner.runAndAssertBuild()
 
-    assertThat(generatedBasePackagePath.resolve("hello")).exists()
-    assertThat(generatedBasePackagePath.resolve("other")).doesNotExist()
-    assertThat(generatedBasePackagePath.resolve("hello/sub")).doesNotExist()
+    assertThat(root.generatedBasePackagePath.resolve("hello")).exists()
+    assertThat(root.generatedBasePackagePath.resolve("other")).doesNotExist()
+    assertThat(root.generatedBasePackagePath.resolve("hello/sub")).doesNotExist()
   }
 
   @Test
-  fun `include package pattern`() {
-    buildFile(
+  @GradleProject("package-filter")
+  fun `include package pattern`(
+    @GradleProject.Root root: File,
+    @GradleProject.Runner runner: GradleRunner,
+  ) {
+    root.buildFile(
       """
         assertJ {
             entryPoints {
@@ -147,18 +83,22 @@ internal class PackageFilter {
         """
     )
 
-    setupTestHelloWorld()
+    root.setupTestHelloWorld()
 
-    runAndAssertBuild()
+    runner.runAndAssertBuild()
 
-    assertThat(generatedBasePackagePath.resolve("hello")).exists()
-    assertThat(generatedBasePackagePath.resolve("other")).doesNotExist()
-    assertThat(generatedBasePackagePath.resolve("hello/sub")).doesNotExist()
+    assertThat(root.generatedBasePackagePath.resolve("hello")).exists()
+    assertThat(root.generatedBasePackagePath.resolve("other")).doesNotExist()
+    assertThat(root.generatedBasePackagePath.resolve("hello/sub")).doesNotExist()
   }
 
   @Test
-  fun `include package that does not exist and valid`() {
-    buildFile(
+  @GradleProject("package-filter")
+  fun `include package that does not exist and valid`(
+    @GradleProject.Root root: File,
+    @GradleProject.Runner runner: GradleRunner,
+  ) {
+    root.buildFile(
       """
         assertJ {
             entryPoints {
@@ -171,18 +111,22 @@ internal class PackageFilter {
         """
     )
 
-    setupTestHelloWorld()
+    root.setupTestHelloWorld()
 
-    runAndAssertBuild()
+    runner.runAndAssertBuild()
 
-    assertThat(generatedBasePackagePath.resolve("hello")).exists()
-    assertThat(generatedBasePackagePath.resolve("other")).doesNotExist()
-    assertThat(generatedBasePackagePath.resolve("hello/sub")).doesNotExist()
+    assertThat(root.generatedBasePackagePath.resolve("hello")).exists()
+    assertThat(root.generatedBasePackagePath.resolve("other")).doesNotExist()
+    assertThat(root.generatedBasePackagePath.resolve("hello/sub")).doesNotExist()
   }
 
   @Test
-  fun `include package double wildcard`() {
-    buildFile(
+  @GradleProject("package-filter")
+  fun `include package double wildcard`(
+    @GradleProject.Root root: File,
+    @GradleProject.Runner runner: GradleRunner,
+  ) {
+    root.buildFile(
       """
         assertJ {
             entryPoints {
@@ -195,18 +139,22 @@ internal class PackageFilter {
         """
     )
 
-    setupTestHelloAndSub()
+    root.setupTestHelloAndSub()
 
-    runAndAssertBuild()
+    runner.runAndAssertBuild()
 
-    assertThat(generatedBasePackagePath.resolve("other")).doesNotExist()
-    assertThat(generatedBasePackagePath.resolve("hello")).exists()
-    assertThat(generatedBasePackagePath.resolve("hello/sub")).exists()
+    assertThat(root.generatedBasePackagePath.resolve("other")).doesNotExist()
+    assertThat(root.generatedBasePackagePath.resolve("hello")).exists()
+    assertThat(root.generatedBasePackagePath.resolve("hello/sub")).exists()
   }
 
   @Test
-  fun `exclude package simple`() {
-    buildFile(
+  @GradleProject("package-filter")
+  fun `exclude package simple`(
+    @GradleProject.Root root: File,
+    @GradleProject.Runner runner: GradleRunner,
+  ) {
+    root.buildFile(
       """
         assertJ {
             entryPoints {
@@ -219,18 +167,22 @@ internal class PackageFilter {
         """
     )
 
-    setupTestHelloAndSub()
+    root.setupTestHelloAndSub()
 
-    runAndAssertBuild()
+    runner.runAndAssertBuild()
 
-    assertThat(generatedBasePackagePath.resolve("hello")).exists()
-    assertThat(generatedBasePackagePath.resolve("hello/sub")).exists()
-    assertThat(generatedBasePackagePath.resolve("other")).doesNotExist()
+    assertThat(root.generatedBasePackagePath.resolve("hello")).exists()
+    assertThat(root.generatedBasePackagePath.resolve("hello/sub")).exists()
+    assertThat(root.generatedBasePackagePath.resolve("other")).doesNotExist()
   }
 
   @Test
-  fun `exclude package pattern`() {
-    buildFile(
+  @GradleProject("package-filter")
+  fun `exclude package pattern`(
+    @GradleProject.Root root: File,
+    @GradleProject.Runner runner: GradleRunner,
+  ) {
+    root.buildFile(
       """
         assertJ {
             entryPoints {
@@ -243,16 +195,16 @@ internal class PackageFilter {
         """
     )
 
-    setupTestHelloAndSub()
+    root.setupTestHelloAndSub()
 
-    runAndAssertBuild()
+    runner.runAndAssertBuild()
 
-    assertThat(generatedBasePackagePath.resolve("other")).doesNotExist()
-    assertThat(generatedBasePackagePath.resolve("hello")).exists()
-    assertThat(generatedBasePackagePath.resolve("hello/sub")).exists()
+    assertThat(root.generatedBasePackagePath.resolve("other")).doesNotExist()
+    assertThat(root.generatedBasePackagePath.resolve("hello")).exists()
+    assertThat(root.generatedBasePackagePath.resolve("hello/sub")).exists()
   }
 
-  private fun setupTestHelloAndSub() = testFile(
+  private fun File.setupTestHelloAndSub() = testFile(
     """
       @Test
       public void checkHello() {
@@ -269,8 +221,12 @@ internal class PackageFilter {
   )
 
   @Test
-  fun `exclude package that does not exist and valid`() {
-    buildFile(
+  @GradleProject("package-filter")
+  fun `exclude package that does not exist and valid`(
+    @GradleProject.Root root: File,
+    @GradleProject.Runner runner: GradleRunner,
+  ) {
+    root.buildFile(
       """
         assertJ {
             entryPoints {
@@ -283,7 +239,7 @@ internal class PackageFilter {
         """
     )
 
-    testFile(
+    root.testFile(
       """
         @Test
         public void checkHello() {
@@ -299,16 +255,20 @@ internal class PackageFilter {
         """
     )
 
-    runAndAssertBuild()
+    runner.runAndAssertBuild()
 
-    assertThat(generatedBasePackagePath.resolve("other")).doesNotExist()
-    assertThat(generatedBasePackagePath.resolve("hello")).exists()
-    assertThat(generatedBasePackagePath.resolve("hello/sub")).exists()
+    assertThat(root.generatedBasePackagePath.resolve("other")).doesNotExist()
+    assertThat(root.generatedBasePackagePath.resolve("hello")).exists()
+    assertThat(root.generatedBasePackagePath.resolve("hello/sub")).exists()
   }
 
   @Test
-  fun `exclude package double wildcard`() {
-    buildFile(
+  @GradleProject("package-filter")
+  fun `exclude package double wildcard`(
+    @GradleProject.Root root: File,
+    @GradleProject.Runner runner: GradleRunner,
+  ) {
+    root.buildFile(
       """
         assertJ {
             entryPoints {
@@ -322,14 +282,15 @@ internal class PackageFilter {
     )
 
     // Since we are excluding _everything_ we need to add a custom test
-    helloWorldTestJava.writeJava(
+    root.helloWorldTestJava.writeJava(
       """
         package org.example;
         
         import org.example.hello.*;
-        import org.example.other.*;
-        import org.junit.Test;
-        import static org.assertj.core.api.Assertions.assertThat;
+import org.example.other.*;
+import org.junit.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
         
         public final class HelloWorldTest {
             @Test
@@ -340,15 +301,19 @@ internal class PackageFilter {
         """
     )
 
-    runAndAssertBuild()
+    runner.runAndAssertBuild()
 
-    assertThat(generatedBasePackagePath.resolve("other")).doesNotExist()
-    assertThat(generatedBasePackagePath.resolve("hello")).doesNotExist()
+    assertThat(root.generatedBasePackagePath.resolve("other")).doesNotExist()
+    assertThat(root.generatedBasePackagePath.resolve("hello")).doesNotExist()
   }
 
   @Test
-  fun `include double wildcard but exclude specific package`() {
-    buildFile(
+  @GradleProject("package-filter")
+  fun `include double wildcard but exclude specific package`(
+    @GradleProject.Root root: File,
+    @GradleProject.Runner runner: GradleRunner,
+  ) {
+    root.buildFile(
       """
         assertJ {
             entryPoints {
@@ -362,16 +327,16 @@ internal class PackageFilter {
         """
     )
 
-    setupTestHelloWorld()
+    root.setupTestHelloWorld()
 
-    runAndAssertBuild()
+    runner.runAndAssertBuild()
 
-    assertThat(generatedBasePackagePath.resolve("other")).doesNotExist()
-    assertThat(generatedBasePackagePath.resolve("hello")).exists()
-    assertThat(generatedBasePackagePath.resolve("hello/sub")).doesNotExist()
+    assertThat(root.generatedBasePackagePath.resolve("other")).doesNotExist()
+    assertThat(root.generatedBasePackagePath.resolve("hello")).exists()
+    assertThat(root.generatedBasePackagePath.resolve("hello/sub")).doesNotExist()
   }
 
-  private fun setupTestHelloWorld(): File = testFile(
+  private fun File.setupTestHelloWorld(): File = testFile(
     """
       @Test
       public void checkHello() {
@@ -381,19 +346,14 @@ internal class PackageFilter {
       """
   )
 
-  private fun runAndAssertBuild() {
-    val result = GradleRunner.create()
-      .withProjectDir(testProjectDir.root)
-      .withDebug(true)
-      .withPluginClasspath()
-      .withArguments("-i", "-s", "test")
-      .build()
+  private fun GradleRunner.runAndAssertBuild() {
+    val result = withDebug(true).withArguments("-i", "-s", "test").build()
 
     assertThat(result.task(":generateAssertJ")).isSuccessful()
     assertThat(result.task(":test")).isSuccessful()
   }
 
-  private fun buildFile(@Language("groovy") configuration: String) {
+  private fun File.buildFile(@Language("groovy") configuration: String) {
     buildFile.writeGroovy(
       """
             // Add required plugins and source sets to the sub projects
@@ -424,7 +384,7 @@ internal class PackageFilter {
     )
   }
 
-  private fun testFile(@Language("java") testContent: String): File {
+  private fun File.testFile(@Language("java") testContent: String): File {
     helloWorldTestJava.writeJava(
       """
             package org.example;

--- a/src/test/projects/classes-filter/build.gradle
+++ b/src/test/projects/classes-filter/build.gradle
@@ -1,0 +1,33 @@
+// Add required plugins and source sets to the sub projects
+plugins {
+    id "org.assertj.generator" // Note must use this syntax
+    id "java"
+}
+
+// Override defaults
+sourceSets {
+    main {
+        $ { configuration.trimIndent() }
+    }
+}
+
+// add some classpath dependencies
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
+
+    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.24.2'
+    testImplementation group: 'junit', name: 'junit', version: '4.13.1'
+}
+
+assertJ {
+    entryPoints {
+        classPackage = "org.example"
+    }
+    classes {
+        include "org.example.hello.HelloWorld"
+    }
+}

--- a/src/test/projects/classes-filter/src/main/java/org/example/HelloWorld.java
+++ b/src/test/projects/classes-filter/src/main/java/org/example/HelloWorld.java
@@ -1,0 +1,12 @@
+package org.example.hello;
+
+public final class HelloWorld {
+
+  // Field
+  public boolean hasSomeBrains = false;
+
+  // Getter
+  public int getFoo() {
+    return -1;
+  }
+}

--- a/src/test/projects/classes-filter/src/main/java/org/example/OtherWorld.java
+++ b/src/test/projects/classes-filter/src/main/java/org/example/OtherWorld.java
@@ -1,0 +1,5 @@
+package org.example.other;
+
+public final class OtherWorld {
+  public boolean isBrainy = false;
+}

--- a/src/test/projects/classes-filter/src/main/java/org/example/sub/SubHelloWorld.java
+++ b/src/test/projects/classes-filter/src/main/java/org/example/sub/SubHelloWorld.java
@@ -1,0 +1,8 @@
+package org.example.hello.sub;
+
+public final class SubHelloWorld {
+  // Getter
+  public int getFoo() {
+    return -1;
+  }
+}

--- a/src/test/projects/entry-point-generation/build.gradle
+++ b/src/test/projects/entry-point-generation/build.gradle
@@ -1,0 +1,33 @@
+// Add required plugins and source sets to the sub projects
+plugins {
+    id "org.assertj.generator" // Note must use this syntax
+    id "java"
+}
+
+// Override defaults
+sourceSets {
+    main {
+        $ { configuration.trimIndent() }
+    }
+}
+
+// add some classpath dependencies
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
+
+    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.24.2'
+    testImplementation group: 'junit', name: 'junit', version: '4.13.1'
+}
+
+assertJ {
+    entryPoints {
+        classPackage = "org.example"
+    }
+    classes {
+        include "org.example.hello.HelloWorld"
+    }
+}

--- a/src/test/projects/entry-point-generation/src/main/java/org/example/HelloWorld.java
+++ b/src/test/projects/entry-point-generation/src/main/java/org/example/HelloWorld.java
@@ -1,0 +1,6 @@
+package org.example;
+
+public final class HelloWorld {
+  // Field
+  public boolean hasSomeBrains = false;
+}

--- a/src/test/projects/entry-point-generation/src/test/java/org/example/HelloWorldTest.java
+++ b/src/test/projects/entry-point-generation/src/test/java/org/example/HelloWorldTest.java
@@ -1,0 +1,14 @@
+package org.example;
+
+import org.junit.*;
+
+public class HelloWorldTest {
+  @Test
+  public void test() {
+    HelloWorld ut = new HelloWorld();
+    HelloWorldAssert.assertThat(ut).doesNotHaveSomeBrains();
+
+    ut.hasSomeBrains = true;
+    HelloWorldAssert.assertThat(ut).hasSomeBrains();
+  }
+}

--- a/src/test/projects/incremental-build/build.gradle.kts
+++ b/src/test/projects/incremental-build/build.gradle.kts
@@ -1,17 +1,23 @@
 plugins {
-    id("org.assertj.generator")
-    `java`
-    id("org.jetbrains.kotlin.jvm") version "1.8.10"
+  id("org.assertj.generator")
+  `java`
+  kotlin("jvm") version "1.9.0"
+}
+
+buildscript {
+  dependencies {
+    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0")
+  }
 }
 
 repositories {
-    mavenCentral()
+  mavenCentral()
 }
 
 dependencies {
-    implementation(kotlin("stdlib"))
-    implementation("javax.annotation:javax.annotation-api:1.3.2")
+  implementation(kotlin("stdlib"))
+  implementation("javax.annotation:javax.annotation-api:1.3.2")
 
-    testImplementation("org.assertj:assertj-core:3.24.2")
-    testImplementation("junit:junit:4.13.1")
+  testImplementation("org.assertj:assertj-core:3.24.2")
+  testImplementation("junit:junit:4.13.1")
 }

--- a/src/test/projects/incremental-build/build.gradle.kts
+++ b/src/test/projects/incremental-build/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    id("org.assertj.generator")
+    `java`
+    id("org.jetbrains.kotlin.jvm") version "1.8.10"
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+    implementation("javax.annotation:javax.annotation-api:1.3.2")
+
+    testImplementation("org.assertj:assertj-core:3.24.2")
+    testImplementation("junit:junit:4.13.1")
+}

--- a/src/test/projects/incremental-build/src/main/java/org/example/H1.java
+++ b/src/test/projects/incremental-build/src/main/java/org/example/H1.java
@@ -1,0 +1,5 @@
+package org.example;
+
+public final class H1 {
+  public boolean isBrainy = false;
+}

--- a/src/test/projects/incremental-build/src/main/java/org/example/H2.java
+++ b/src/test/projects/incremental-build/src/main/java/org/example/H2.java
@@ -1,0 +1,5 @@
+package org.example;
+
+public final class H2 {
+  public boolean isBrainy = false;
+}

--- a/src/test/projects/incremental-build/src/test/java/org/example/H1Test.java
+++ b/src/test/projects/incremental-build/src/test/java/org/example/H1Test.java
@@ -1,0 +1,13 @@
+package org.example;
+
+import org.junit.Test;
+
+import static org.example.H1Assert.assertThat;
+
+public final class H1Test {
+  @Test
+  public void check() {
+    H1 hw = new H1();
+    assertThat(hw).isNotBrainy();
+  }
+}

--- a/src/test/projects/kotlin-sources-build/build.gradle.kts
+++ b/src/test/projects/kotlin-sources-build/build.gradle.kts
@@ -1,0 +1,17 @@
+plugins {
+    id("org.assertj.generator")
+    `java`
+    id("org.jetbrains.kotlin.jvm") version "1.8.10"
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation(kotlin("stdlib"))
+    implementation("javax.annotation:javax.annotation-api:1.3.2")
+
+    testImplementation("org.assertj:assertj-core:3.24.2")
+    testImplementation("junit:junit:4.13.1")
+}

--- a/src/test/projects/kotlin-sources-build/src/main/kotlin/org/example/HelloWorld2.kt
+++ b/src/test/projects/kotlin-sources-build/src/main/kotlin/org/example/HelloWorld2.kt
@@ -1,0 +1,9 @@
+package org.example
+
+class HelloWorld2 {
+  // Getter & Setter
+  val isBrains = false
+
+  // Getter
+  val foo = -1
+}

--- a/src/test/projects/kotlin-sources-build/src/test/kotlin/org/example/HelloWorldTest.kt
+++ b/src/test/projects/kotlin-sources-build/src/test/kotlin/org/example/HelloWorldTest.kt
@@ -1,0 +1,13 @@
+package org.example
+
+import org.junit.Test
+import org.example.Assertions.assertThat
+
+internal class HelloWorldTest {
+  @Test
+  fun check() {
+    val hw = HelloWorld2()
+    assertThat(hw).hasFoo(-1)
+        .isNotBrains()
+  }
+}

--- a/src/test/projects/output-directory-parameter/build.gradle
+++ b/src/test/projects/output-directory-parameter/build.gradle
@@ -1,0 +1,33 @@
+// Add required plugins and source sets to the sub projects
+plugins {
+    id "org.assertj.generator" // Note must use this syntax
+    id "java"
+}
+
+// Override defaults
+sourceSets {
+    main {
+        $ { configuration.trimIndent() }
+    }
+}
+
+// add some classpath dependencies
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
+
+    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.24.2'
+    testImplementation group: 'junit', name: 'junit', version: '4.13.1'
+}
+
+assertJ {
+    entryPoints {
+        classPackage = "org.example"
+    }
+    classes {
+        include "org.example.hello.HelloWorld"
+    }
+}

--- a/src/test/projects/output-directory-parameter/src/main/java/org/example/Main.java
+++ b/src/test/projects/output-directory-parameter/src/main/java/org/example/Main.java
@@ -1,0 +1,6 @@
+package org.example;
+
+public final class Main {
+  // Field
+  public boolean hasSomeBrains = false;
+}

--- a/src/test/projects/output-directory-parameter/src/main/test/java/org/example/HelloWorldTest.java
+++ b/src/test/projects/output-directory-parameter/src/main/test/java/org/example/HelloWorldTest.java
@@ -1,0 +1,14 @@
+package org.example;
+
+import org.junit.*;
+
+public class HelloWorldTest {
+  @Test
+  public void test() {
+    HelloWorld ut = new HelloWorld();
+    HelloWorldAssert.assertThat(ut).doesNotHaveSomeBrains();
+
+    ut.hasSomeBrains = true;
+    HelloWorldAssert.assertThat(ut).hasSomeBrains();
+  }
+}

--- a/src/test/projects/package-filter/build.gradle
+++ b/src/test/projects/package-filter/build.gradle
@@ -1,0 +1,33 @@
+// Add required plugins and source sets to the sub projects
+plugins {
+    id "org.assertj.generator" // Note must use this syntax
+    id "java"
+}
+
+// Override defaults
+sourceSets {
+    main {
+        $ { configuration.trimIndent() }
+    }
+}
+
+// add some classpath dependencies
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
+
+    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.24.2'
+    testImplementation group: 'junit', name: 'junit', version: '4.13.1'
+}
+
+assertJ {
+    entryPoints {
+        classPackage = "org.example"
+    }
+    classes {
+        include "org.example.hello.HelloWorld"
+    }
+}

--- a/src/test/projects/package-filter/src/main/java/org/example/HelloWorld.java
+++ b/src/test/projects/package-filter/src/main/java/org/example/HelloWorld.java
@@ -1,0 +1,12 @@
+package org.example.hello;
+
+public final class HelloWorld {
+
+  // Field
+  public boolean hasSomeBrains = false;
+
+  // Getter
+  public int getFoo() {
+    return -1;
+  }
+}

--- a/src/test/projects/package-filter/src/main/java/org/example/OtherWorld.java
+++ b/src/test/projects/package-filter/src/main/java/org/example/OtherWorld.java
@@ -1,0 +1,5 @@
+package org.example.other;
+
+public final class OtherWorld {
+  public boolean isBrainy = false;
+}

--- a/src/test/projects/package-filter/src/main/java/org/example/sub/SubHelloWorld.java
+++ b/src/test/projects/package-filter/src/main/java/org/example/sub/SubHelloWorld.java
@@ -1,0 +1,8 @@
+package org.example.hello.sub;
+
+public final class SubHelloWorld {
+  // Getter
+  public int getFoo() {
+    return -1;
+  }
+}

--- a/src/test/projects/package-filter/src/test/java/org/example/HelloWorldTest.java
+++ b/src/test/projects/package-filter/src/test/java/org/example/HelloWorldTest.java
@@ -1,0 +1,14 @@
+package org.example;
+
+import org.junit.*;
+
+public class HelloWorldTest {
+  @Test
+  public void test() {
+    HelloWorld ut = new HelloWorld();
+    HelloWorldAssert.assertThat(ut).doesNotHaveSomeBrains();
+
+    ut.hasSomeBrains = true;
+    HelloWorldAssert.assertThat(ut).hasSomeBrains();
+  }
+}

--- a/src/test/projects/simple-build/build.gradle
+++ b/src/test/projects/simple-build/build.gradle
@@ -1,0 +1,18 @@
+// Add required plugins and source sets to the sub projects
+plugins {
+    id "org.assertj.generator" // Note must use this syntax
+    id "java"
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
+
+    // https://mvnrepository.com/artifact/org.assertj/assertj-core
+    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.24.2'
+
+    testImplementation group: 'junit', name: 'junit', version: '4.13.1'
+}

--- a/src/test/projects/simple-build/src/main/java/org/example/HelloWorld.java
+++ b/src/test/projects/simple-build/src/main/java/org/example/HelloWorld.java
@@ -1,0 +1,12 @@
+package org.example;
+
+public final class HelloWorld {
+
+  // Field
+  public boolean hasSomeBrains = false;
+
+  // Getter
+  public int getFoo() {
+    return -1;
+  }
+}

--- a/src/test/projects/simple-build/src/main/java/org/example/OtherNestedWorld.java
+++ b/src/test/projects/simple-build/src/main/java/org/example/OtherNestedWorld.java
@@ -1,0 +1,9 @@
+package org.example;
+
+public final class OtherNestedWorld {
+  public boolean isBrainy = false;
+
+  public static class Nested {
+    public boolean isSomethingElse = false;
+  }
+}

--- a/src/test/projects/simple-build/src/main/java/org/example/OtherWorld.java
+++ b/src/test/projects/simple-build/src/main/java/org/example/OtherWorld.java
@@ -1,0 +1,5 @@
+package org.example;
+
+public final class OtherWorld {
+  public boolean isBrainy = false;
+}

--- a/src/test/projects/simple-build/src/test/java/org/example/HelloWorldTest.java
+++ b/src/test/projects/simple-build/src/test/java/org/example/HelloWorldTest.java
@@ -1,0 +1,27 @@
+package org.example;
+
+import org.junit.Test;
+
+import static org.example.Assertions.assertThat;
+
+public final class HelloWorldTest {
+
+  @Test
+  public void check() {
+    HelloWorld hw = new HelloWorld();
+    assertThat(hw).hasFoo(-1)
+        .doesNotHaveSomeBrains();
+  }
+
+  @Test
+  public void checkClassWithNested() {
+    OtherNestedWorld ow = new OtherNestedWorld();
+    assertThat(ow).isNotBrainy();
+  }
+
+  @Test
+  public void checkNestedClass() {
+    OtherNestedWorld.Nested n = new OtherNestedWorld.Nested();
+    assertThat(n).isNotSomethingElse();
+  }
+}

--- a/src/test/projects/skip-package-info/build.gradle
+++ b/src/test/projects/skip-package-info/build.gradle
@@ -1,0 +1,18 @@
+// Add required plugins and source sets to the sub projects
+plugins {
+    id "org.assertj.generator" // Note must use this syntax
+    id "java"
+}
+
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
+
+    // https://mvnrepository.com/artifact/org.assertj/assertj-core
+    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.24.2'
+
+    testImplementation group: 'junit', name: 'junit', version: '4.13.1'
+}

--- a/src/test/projects/skip-package-info/src/main/java/org/example/HelloWorld.java
+++ b/src/test/projects/skip-package-info/src/main/java/org/example/HelloWorld.java
@@ -1,0 +1,12 @@
+package org.example;
+
+public final class HelloWorld {
+
+  // Field
+  public boolean hasSomeBrains = false;
+
+  // Getter
+  public int getFoo() {
+    return -1;
+  }
+}

--- a/src/test/projects/skip-package-info/src/main/java/org/example/OtherWorld.java
+++ b/src/test/projects/skip-package-info/src/main/java/org/example/OtherWorld.java
@@ -1,0 +1,5 @@
+package org.example;
+
+public final class OtherWorld {
+  public boolean isBrainy = false;
+}

--- a/src/test/projects/skip-package-info/src/main/java/org/example/package-info.java
+++ b/src/test/projects/skip-package-info/src/main/java/org/example/package-info.java
@@ -1,0 +1,4 @@
+/**
+ * Some javadoc comments about the package.
+ */
+package org.example;

--- a/src/test/projects/skip-package-info/src/test/java/org/example/HelloWorldTest.java
+++ b/src/test/projects/skip-package-info/src/test/java/org/example/HelloWorldTest.java
@@ -1,0 +1,15 @@
+package org.example;
+
+import org.junit.Test;
+
+import static org.example.HelloWorldAssert.assertThat;
+
+public final class HelloWorldTest {
+
+  @Test
+  public void check() {
+    HelloWorld hw = new HelloWorld();
+    assertThat(hw).hasFoo(-1)
+        .doesNotHaveSomeBrains();
+  }
+}

--- a/src/test/projects/skip-parameter/build.gradle
+++ b/src/test/projects/skip-parameter/build.gradle
@@ -1,0 +1,33 @@
+// Add required plugins and source sets to the sub projects
+plugins {
+    id "org.assertj.generator" // Note must use this syntax
+    id "java"
+}
+
+// Override defaults
+sourceSets {
+    main {
+        $ { configuration.trimIndent() }
+    }
+}
+
+// add some classpath dependencies
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
+
+    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.24.2'
+    testImplementation group: 'junit', name: 'junit', version: '4.13.1'
+}
+
+assertJ {
+    entryPoints {
+        classPackage = "org.example"
+    }
+    classes {
+        include "org.example.hello.HelloWorld"
+    }
+}

--- a/src/test/projects/skip-parameter/src/main/java/org/example/Main.java
+++ b/src/test/projects/skip-parameter/src/main/java/org/example/Main.java
@@ -1,0 +1,6 @@
+package org.example;
+
+public final class Main {
+  // Field
+  public boolean hasSomeBrains = false;
+}

--- a/src/test/projects/skip-parameter/src/other/java/org/example/Other.java
+++ b/src/test/projects/skip-parameter/src/other/java/org/example/Other.java
@@ -1,0 +1,6 @@
+package org.example;
+
+public final class Other {
+  // Field
+  public boolean hasSomeBrains = false;
+}

--- a/src/test/projects/template-changes/build.gradle
+++ b/src/test/projects/template-changes/build.gradle
@@ -1,0 +1,33 @@
+// Add required plugins and source sets to the sub projects
+plugins {
+    id "org.assertj.generator" // Note must use this syntax
+    id "java"
+}
+
+// Override defaults
+sourceSets {
+    main {
+        $ { configuration.trimIndent() }
+    }
+}
+
+// add some classpath dependencies
+repositories {
+    mavenCentral()
+}
+
+dependencies {
+    implementation group: 'javax.annotation', name: 'javax.annotation-api', version: '1.3.2'
+
+    testImplementation group: 'org.assertj', name: 'assertj-core', version: '3.24.2'
+    testImplementation group: 'junit', name: 'junit', version: '4.13.1'
+}
+
+assertJ {
+    entryPoints {
+        classPackage = "org.example"
+    }
+    classes {
+        include "org.example.hello.HelloWorld"
+    }
+}

--- a/src/test/projects/template-changes/src/main/java/org/example/HelloWorld.java
+++ b/src/test/projects/template-changes/src/main/java/org/example/HelloWorld.java
@@ -1,0 +1,8 @@
+package org.example;
+
+public final class HelloWorld {
+  // Getter
+  public int getFoo() {
+    return -1;
+  }
+}


### PR DESCRIPTION
…aster execution

This was mostly done because I want to use my own library more places to make sure it's sound. This makes the tests run faster, though!

This also sets up CI to run across more versions of Gradle.