### PR TITLE
[Tests] Add src/test/projects as resources

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,6 +92,14 @@ tasks.test {
   jvmArgs("-Djunit.jupiter.extensions.autodetection.enabled=true")
 }
 
+sourceSets {
+  test {
+    resources {
+      srcDir("src/test/projects")
+    }
+  }
+}
+
 tasks.check {
   dependsOn(tasks.named("projectHealth"))
 }

--- a/src/test/projects/incremental-build/build.gradle.kts
+++ b/src/test/projects/incremental-build/build.gradle.kts
@@ -4,12 +4,6 @@ plugins {
   kotlin("jvm") version "1.9.0"
 }
 
-buildscript {
-  dependencies {
-    classpath("org.jetbrains.kotlin:kotlin-gradle-plugin:1.9.0")
-  }
-}
-
 repositories {
   mavenCentral()
 }


### PR DESCRIPTION
This is to properly associate gradle with these files to make sure if they change we re-run tests.