### PR TITLE
chore: Update CI to better test plugin in diff environments

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -3,7 +3,12 @@ on: [ push, pull_request ]
 
 jobs:
   ci:
-    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        gradle-version: [ '7.6.4', '8.7', '8.12.1', 'current' ]
+        os: [ 'ubuntu-latest', 'macos-latest', 'windows-latest' ]
+
+    runs-on: ${{ matrix.os }}
     if: github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/main')
 
     steps:
@@ -18,7 +23,7 @@ jobs:
 
       - uses: gradle/actions/setup-gradle@v4
         with:
-          gradle-version: '8.12.1'
+          gradle-version: 8.12.1
 
       - run:
-          ./gradlew check --continue
+          ./gradlew check --continue -Dtest.gradle.version.override='${{ matrix.gradle-version }}'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,3 +27,4 @@ jobs:
 
       - run:
           ./gradlew check --continue -Dtest.gradle.version.override='${{ matrix.gradle-version }}'
+        shell: bash

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,6 +98,8 @@ tasks.test {
   useJUnitPlatform()
 
   jvmArgs("-Djunit.jupiter.extensions.autodetection.enabled=true")
+
+  systemProperty("test.gradle.version", gradle.gradleVersion)
 }
 
 sourceSets {

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,2 +1,7 @@
 org.gradle.configuration-cache=true
 org.gradle.caching=true
+org.gradle.parallel=true
+org.gradle.daemon=true
+
+org.gradle.jvmargs=-Xmx1024M
+

--- a/src/test/kotlin/org/assertj/generator/gradle/IncrementalBuild.kt
+++ b/src/test/kotlin/org/assertj/generator/gradle/IncrementalBuild.kt
@@ -14,6 +14,7 @@ package org.assertj.generator.gradle
 
 import net.navatwo.gradle.testkit.junit5.GradleProject
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.generator.gradle.TestUtils.withCiGradle
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.Test
 import java.io.File
@@ -39,7 +40,7 @@ internal class IncrementalBuild {
     @GradleProject.Root root: File,
     @GradleProject.Runner runner: GradleRunner,
   ) {
-    val buildRunner = runner.withArguments("-i", "-s", "build")
+    val buildRunner = runner.withCiGradle().withArguments("-i", "-s", "build")
 
     val firstBuild = buildRunner.build()
 
@@ -61,7 +62,7 @@ internal class IncrementalBuild {
     @GradleProject.Root root: File,
     @GradleProject.Runner runner: GradleRunner,
   ) {
-    val buildRunner = runner.withArguments("-i", "-s", "build")
+    val buildRunner = runner.withCiGradle().withArguments("-i", "-s", "build")
 
     val firstBuild = buildRunner.build()
 

--- a/src/test/kotlin/org/assertj/generator/gradle/KotlinSourcesBuild.kt
+++ b/src/test/kotlin/org/assertj/generator/gradle/KotlinSourcesBuild.kt
@@ -14,6 +14,7 @@ package org.assertj.generator.gradle
 
 import net.navatwo.gradle.testkit.junit5.GradleProject
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.generator.gradle.TestUtils.withCiGradle
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.Test
 import java.io.File
@@ -25,7 +26,7 @@ internal class KotlinSourcesBuild {
     @GradleProject.Root root: File,
     @GradleProject.Runner runner: GradleRunner,
   ) {
-    val result = runner.withArguments("-i", "-s", "test").build()
+    val result = runner.withCiGradle().withArguments("-i", "-s", "test").build()
 
     assertThat(result.task(":generateAssertJ")).isSuccessful()
     assertThat(result.task(":test")).isSuccessful()

--- a/src/test/kotlin/org/assertj/generator/gradle/SimpleBuild.kt
+++ b/src/test/kotlin/org/assertj/generator/gradle/SimpleBuild.kt
@@ -14,6 +14,7 @@ package org.assertj.generator.gradle
 
 import net.navatwo.gradle.testkit.junit5.GradleProject
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.generator.gradle.TestUtils.withCiGradle
 import org.assertj.generator.gradle.TestUtils.writeBuildFile
 import org.assertj.generator.gradle.TestUtils.writeDefaultBuildFile
 import org.gradle.testkit.runner.GradleRunner
@@ -36,7 +37,7 @@ internal class SimpleBuild {
   ) {
     root.buildFile.writeDefaultBuildFile()
 
-    val result = runner.withArguments("-i", "-s", "test").build()
+    val result = runner.withCiGradle().withArguments("-i", "-s", "test").build()
 
     assertThat(result.task(":generateAssertJ")).isSuccessful()
     assertThat(result.task(":test")).isSuccessful()
@@ -60,7 +61,7 @@ internal class SimpleBuild {
       """
     )
 
-    val result = runner.withArguments("-i", "-s", "test").build()
+    val result = runner.withCiGradle().withArguments("-i", "-s", "test").build()
 
     assertThat(result.task(":generateAssertJ")).isSuccessful()
     assertThat(result.task(":test")).isSuccessful()

--- a/src/test/kotlin/org/assertj/generator/gradle/SkipPackageInfo.kt
+++ b/src/test/kotlin/org/assertj/generator/gradle/SkipPackageInfo.kt
@@ -14,6 +14,7 @@ package org.assertj.generator.gradle
 
 import net.navatwo.gradle.testkit.junit5.GradleProject
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.generator.gradle.TestUtils.withCiGradle
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.Test
 import java.io.File
@@ -33,7 +34,7 @@ internal class SkipPackageInfo {
     @GradleProject.Root root: File,
     @GradleProject.Runner runner: GradleRunner,
   ) {
-    val result = runner.withArguments("-i", "-s", "check").build()
+    val result = runner.withCiGradle().withArguments("-i", "-s", "check").build()
 
     assertThat(result.task(":generateAssertJ")).isSuccessful()
     assertThat(result.task(":test")).isSuccessful()

--- a/src/test/kotlin/org/assertj/generator/gradle/TestUtils.kt
+++ b/src/test/kotlin/org/assertj/generator/gradle/TestUtils.kt
@@ -12,6 +12,7 @@
  */
 package org.assertj.generator.gradle
 
+import org.gradle.testkit.runner.GradleRunner
 import org.intellij.lang.annotations.Language
 import java.io.File
 
@@ -76,5 +77,12 @@ internal object TestUtils {
     )
   }
 
-  fun File.writeDefaultBuildKts(): Unit = this.writeBuildKts("")
+  fun GradleRunner.withCiGradle(): GradleRunner {
+    return withGradleVersion(
+      System.getProperty(
+        "test.gradle.version.override",
+        System.getProperty("test.gradle.version")
+      )
+    )
+  }
 }

--- a/src/test/kotlin/org/assertj/generator/gradle/parameter/ClassesFilter.kt
+++ b/src/test/kotlin/org/assertj/generator/gradle/parameter/ClassesFilter.kt
@@ -14,6 +14,7 @@ package org.assertj.generator.gradle.parameter
 
 import net.navatwo.gradle.testkit.junit5.GradleProject
 import org.assertj.core.api.Assertions.assertThat
+import org.assertj.generator.gradle.TestUtils.withCiGradle
 import org.assertj.generator.gradle.isSuccessful
 import org.assertj.generator.gradle.writeGroovy
 import org.assertj.generator.gradle.writeJava
@@ -77,7 +78,7 @@ internal class ClassesFilter {
 
     root.setupTestHelloWorld()
 
-    runner.runAndAssertBuild()
+    runner.withCiGradle().runAndAssertBuild()
 
     assertThat(root.generatedBasePackagePath.resolve("hello")).exists()
     assertThat(root.generatedBasePackagePath.resolve("other")).doesNotExist()

--- a/src/test/kotlin/org/assertj/generator/gradle/parameter/EntryPointGeneration.kt
+++ b/src/test/kotlin/org/assertj/generator/gradle/parameter/EntryPointGeneration.kt
@@ -15,10 +15,10 @@ package org.assertj.generator.gradle.parameter
 import net.navatwo.gradle.testkit.junit5.GradleProject
 import org.assertj.assertions.generator.AssertionsEntryPointType
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
+import org.assertj.generator.gradle.TestUtils.withCiGradle
 import org.assertj.generator.gradle.TestUtils.writeBuildFile
 import org.assertj.generator.gradle.isSuccessful
 import org.assertj.generator.gradle.isUpToDate
-import org.assertj.generator.gradle.TestUtils.withCiGradle
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.Test
 import java.io.File

--- a/src/test/kotlin/org/assertj/generator/gradle/parameter/EntryPointGeneration.kt
+++ b/src/test/kotlin/org/assertj/generator/gradle/parameter/EntryPointGeneration.kt
@@ -18,6 +18,7 @@ import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.assertj.generator.gradle.TestUtils.writeBuildFile
 import org.assertj.generator.gradle.isSuccessful
 import org.assertj.generator.gradle.isUpToDate
+import org.assertj.generator.gradle.TestUtils.withCiGradle
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.Test
 import java.io.File
@@ -55,7 +56,7 @@ internal class EntryPointGeneration {
          """
     )
 
-    val result = runner.withArguments("-i", "-s", "test").build()
+    val result = runner.withCiGradle().withArguments("-i", "-s", "test").build()
 
     assertThat(result.task(":generateAssertJ")).isSuccessful()
     assertThat(result.task(":test")).isSuccessful()

--- a/src/test/kotlin/org/assertj/generator/gradle/parameter/OutputDirectoryParameter.kt
+++ b/src/test/kotlin/org/assertj/generator/gradle/parameter/OutputDirectoryParameter.kt
@@ -14,10 +14,10 @@ package org.assertj.generator.gradle.parameter
 
 import net.navatwo.gradle.testkit.junit5.GradleProject
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
+import org.assertj.generator.gradle.TestUtils.withCiGradle
 import org.assertj.generator.gradle.TestUtils.writeBuildFile
 import org.assertj.generator.gradle.capitalized
 import org.assertj.generator.gradle.isSuccessful
-import org.assertj.generator.gradle.TestUtils.withCiGradle
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.Test
 import java.io.File

--- a/src/test/kotlin/org/assertj/generator/gradle/parameter/OutputDirectoryParameter.kt
+++ b/src/test/kotlin/org/assertj/generator/gradle/parameter/OutputDirectoryParameter.kt
@@ -17,7 +17,7 @@ import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.assertj.generator.gradle.TestUtils.writeBuildFile
 import org.assertj.generator.gradle.capitalized
 import org.assertj.generator.gradle.isSuccessful
-import org.gradle.configurationcache.extensions.capitalized
+import org.assertj.generator.gradle.TestUtils.withCiGradle
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.Test
 import java.io.File
@@ -51,7 +51,10 @@ internal class OutputDirectoryParameter {
         """
     )
 
-    val result = runner.withArguments("-i", "-s", "test").build()
+    val result = runner
+      .withCiGradle()
+      .withArguments("-i", "-s", "test")
+      .build()
 
     assertThat(result.task(":generateAssertJ")).isSuccessful()
     assertThat(result.task(":test")).isSuccessful()

--- a/src/test/kotlin/org/assertj/generator/gradle/parameter/PackageFilter.kt
+++ b/src/test/kotlin/org/assertj/generator/gradle/parameter/PackageFilter.kt
@@ -15,6 +15,7 @@ package org.assertj.generator.gradle.parameter
 import net.navatwo.gradle.testkit.junit5.GradleProject
 import org.assertj.core.api.Assertions.assertThat
 import org.assertj.generator.gradle.isSuccessful
+import org.assertj.generator.gradle.TestUtils.withCiGradle
 import org.assertj.generator.gradle.writeGroovy
 import org.assertj.generator.gradle.writeJava
 import org.gradle.testkit.runner.GradleRunner
@@ -347,7 +348,10 @@ import static org.assertj.core.api.Assertions.assertThat;
   )
 
   private fun GradleRunner.runAndAssertBuild() {
-    val result = withDebug(true).withArguments("-i", "-s", "test").build()
+    val result = withDebug(true)
+      .withCiGradle()
+      .withArguments("-i", "-s", "test")
+      .build()
 
     assertThat(result.task(":generateAssertJ")).isSuccessful()
     assertThat(result.task(":test")).isSuccessful()

--- a/src/test/kotlin/org/assertj/generator/gradle/parameter/PackageFilter.kt
+++ b/src/test/kotlin/org/assertj/generator/gradle/parameter/PackageFilter.kt
@@ -14,8 +14,8 @@ package org.assertj.generator.gradle.parameter
 
 import net.navatwo.gradle.testkit.junit5.GradleProject
 import org.assertj.core.api.Assertions.assertThat
-import org.assertj.generator.gradle.isSuccessful
 import org.assertj.generator.gradle.TestUtils.withCiGradle
+import org.assertj.generator.gradle.isSuccessful
 import org.assertj.generator.gradle.writeGroovy
 import org.assertj.generator.gradle.writeJava
 import org.gradle.testkit.runner.GradleRunner

--- a/src/test/kotlin/org/assertj/generator/gradle/parameter/SkipParameter.kt
+++ b/src/test/kotlin/org/assertj/generator/gradle/parameter/SkipParameter.kt
@@ -17,6 +17,7 @@ import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.assertj.generator.gradle.TestUtils.writeBuildFile
 import org.assertj.generator.gradle.capitalized
 import org.assertj.generator.gradle.isSuccessful
+import org.assertj.generator.gradle.TestUtils.withCiGradle
 import org.gradle.configurationcache.extensions.capitalized
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.Test
@@ -71,7 +72,7 @@ internal class SkipParameter {
         """
     )
 
-    val result = runner.withArguments("-i", "-s", "test").build()
+    val result = runner.withCiGradle().withArguments("-i", "-s", "test").build()
 
     assertThat(result.task(":generateAssertJ")).isSuccessful()
     assertThat(result.task(":test")).isSuccessful()

--- a/src/test/kotlin/org/assertj/generator/gradle/parameter/SkipParameter.kt
+++ b/src/test/kotlin/org/assertj/generator/gradle/parameter/SkipParameter.kt
@@ -14,10 +14,10 @@ package org.assertj.generator.gradle.parameter
 
 import net.navatwo.gradle.testkit.junit5.GradleProject
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
+import org.assertj.generator.gradle.TestUtils.withCiGradle
 import org.assertj.generator.gradle.TestUtils.writeBuildFile
 import org.assertj.generator.gradle.capitalized
 import org.assertj.generator.gradle.isSuccessful
-import org.assertj.generator.gradle.TestUtils.withCiGradle
 import org.gradle.configurationcache.extensions.capitalized
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.Test

--- a/src/test/kotlin/org/assertj/generator/gradle/parameter/TemplateChanges.kt
+++ b/src/test/kotlin/org/assertj/generator/gradle/parameter/TemplateChanges.kt
@@ -14,10 +14,10 @@ package org.assertj.generator.gradle.parameter
 
 import net.navatwo.gradle.testkit.junit5.GradleProject
 import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
+import org.assertj.generator.gradle.TestUtils.withCiGradle
 import org.assertj.generator.gradle.TestUtils.writeBuildFile
 import org.assertj.generator.gradle.isSuccessful
 import org.assertj.generator.gradle.isUpToDate
-import org.assertj.generator.gradle.TestUtils.withCiGradle
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.Test
 import java.io.File

--- a/src/test/kotlin/org/assertj/generator/gradle/parameter/TemplateChanges.kt
+++ b/src/test/kotlin/org/assertj/generator/gradle/parameter/TemplateChanges.kt
@@ -17,6 +17,7 @@ import org.assertj.core.api.AssertionsForInterfaceTypes.assertThat
 import org.assertj.generator.gradle.TestUtils.writeBuildFile
 import org.assertj.generator.gradle.isSuccessful
 import org.assertj.generator.gradle.isUpToDate
+import org.assertj.generator.gradle.TestUtils.withCiGradle
 import org.gradle.testkit.runner.GradleRunner
 import org.junit.jupiter.api.Test
 import java.io.File
@@ -58,7 +59,7 @@ internal class TemplateChanges {
         """
     )
 
-    val result = runner.withArguments("-i", "-s", "test").build()
+    val result = runner.withCiGradle().withArguments("-i", "-s", "test").build()
 
     assertThat(result.task(":generateAssertJ")).isSuccessful()
     assertThat(result.task(":test")).isSuccessful()
@@ -90,7 +91,7 @@ internal class TemplateChanges {
       """
     )
 
-    val testRunner = runner.withArguments("-i", "-s", "test")
+    val testRunner = runner.withCiGradle().withArguments("-i", "-s", "test")
 
     val result = testRunner.build()
 
@@ -124,7 +125,7 @@ internal class TemplateChanges {
       """
     )
 
-    val testRunner = runner.withArguments("-i", "-s", "test")
+    val testRunner = runner.withCiGradle().withArguments("-i", "-s", "test")
 
     val result = testRunner.build()
 
@@ -163,7 +164,7 @@ internal class TemplateChanges {
         """
     )
 
-    val testRunner = runner.withArguments("-i", "-s", "test")
+    val testRunner = runner.withCiGradle().withArguments("-i", "-s", "test")
 
     val result = testRunner.build()
 
@@ -221,7 +222,7 @@ internal class TemplateChanges {
         """
     )
 
-    val testRunner = runner.withArguments("-i", "-s", "test")
+    val testRunner = runner.withCiGradle().withArguments("-i", "-s", "test")
 
     val result = testRunner.build()
 
@@ -290,7 +291,7 @@ internal class TemplateChanges {
         """
     )
 
-    val testRunner = runner.withArguments("-i", "-s", "test")
+    val testRunner = runner.withCiGradle().withArguments("-i", "-s", "test")
 
     val result = testRunner.build()
 
@@ -334,7 +335,7 @@ internal class TemplateChanges {
         """
     )
 
-    val result = runner.withArguments("-i", "-s", "generateAssertJ").buildAndFail()
+    val result = runner.withCiGradle().withArguments("-i", "-s", "generateAssertJ").buildAndFail()
 
     assertThat(result.output).contains("wholeNumberAssertion")
   }


### PR DESCRIPTION
Previously, we ran the plugin compilation itself against older gradle versions. This isn't actually what happens for users, this changes our versions to instead change how we execute our tests. 

We test and verify against versions roughly 1 year old for backwards compatibility.